### PR TITLE
Extract rate limit error to fix TypeError when limit exceed.

### DIFF
--- a/designateclient/exceptions.py
+++ b/designateclient/exceptions.py
@@ -82,3 +82,7 @@ class NotFound(RemoteError):
 
 class OverQuota(RemoteError):
     pass
+
+
+class TooManyRequests(RemoteError):
+    pass

--- a/designateclient/tests/test_exceptions.py
+++ b/designateclient/tests/test_exceptions.py
@@ -61,3 +61,18 @@ class RemoteErrorTestCase(base.TestCase):
         self.response_dict['unknown'] = 'fake'
         remote_err = exceptions.RemoteError(**self.response_dict)
         self.assertEqual(expected_msg, remote_err.message)
+
+
+class TooManyErrorsTestCase(base.TestCase):
+    response_dict = {
+        'message': 'Too Many Requests',
+        'status': '429 Too Many Requests',
+        'code': 429,
+        'request_id': 1234
+    }
+
+    def test_get_error_message(self):
+        expected_msg = 'Too Many Requests'
+        self.response_dict['message'] = expected_msg
+        remote_err = exceptions.TooManyRequests(**self.response_dict)
+        self.assertEqual(expected_msg, remote_err.message)

--- a/designateclient/tests/v2/test_zones.py
+++ b/designateclient/tests/v2/test_zones.py
@@ -455,13 +455,13 @@ class TestZoneShared(v2.APIV2TestCase, v2.CrudMixin):
             self.new_ref()
         ]
 
-        parts = ["zones", self.zone_id, "shares"]
+        parts = ["zones", "shares"]
         self.stub_entity('GET', parts=parts, entity={"shared_zones": items})
 
         listed = self.client.zone_share.list(self.zone_id)
 
         self.assertList(items, listed)
-        self.assertQueryStringIs("")
+        self.assertQueryStringIs(f"zone_id={self.zone_id}")
 
     def test_delete_zone_share(self):
         ref = self.new_ref()

--- a/designateclient/v2/client.py
+++ b/designateclient/v2/client.py
@@ -13,6 +13,9 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+
+import json
+
 from keystoneauth1 import adapter
 
 from designateclient import exceptions
@@ -53,6 +56,15 @@ class DesignateAdapter(adapter.LegacyJsonAdapter):
         self.hard_delete = kwargs.pop('hard_delete', False)
         self.sudo_project_id = kwargs.pop('sudo_project_id', None)
         super(self.__class__, self).__init__(*args, **kwargs)
+
+    def _extract_rate_limit_error(self, body):
+        try:
+            resp_dict = json.loads(body)
+            if "error" in resp_dict:
+                return resp_dict['error']
+        except (TypeError, KeyError):
+            return body
+        return body
 
     def request(self, *args, **kwargs):
         kwargs.setdefault('raise_exc', False)
@@ -111,6 +123,10 @@ class DesignateAdapter(adapter.LegacyJsonAdapter):
             raise exceptions.Conflict(**response_payload)
         elif response.status_code == 413:
             raise exceptions.OverQuota(**response_payload)
+        elif response.status_code == 429:
+            if isinstance(body, str):
+                response_payload = self._extract_rate_limit_error(body)
+            raise exceptions.TooManyRequests(**response_payload)
         elif response.status_code >= 500:
             raise exceptions.Unknown(**response_payload)
         return response, body

--- a/designateclient/v2/zones.py
+++ b/designateclient/v2/zones.py
@@ -182,7 +182,7 @@ class ZoneImportsController(V2Controller):
         if pool_id:
             headers['X-Designate-Pool-ID'] = pool_id
         if force:
-            headers['X-Designate-Force-Import'] = force
+            headers['X-Designate-Force-Import'] = str(force)
         return self._post('/zones/tasks/imports', data=zone_file_contents,
                           headers=headers)
 

--- a/designateclient/v2/zones.py
+++ b/designateclient/v2/zones.py
@@ -207,6 +207,7 @@ class ZoneShareController(V2Controller):
     def list(self, zone=None, criterion=None, marker=None, limit=None):
         if zone:
             zone_id = v2_utils.resolve_by_name(self.client.zones.list, zone)
+            criterion = dict()
             criterion['zone_id'] = zone_id
 
         url = self.build_url('/zones/shares',


### PR DESCRIPTION
Rate limit middleware have different response format then Openstack API. Check that response have rate limit error and return correct response instead of TypeError.